### PR TITLE
Add Jest code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+coverage

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
+    "test-coverage": "jest --coverage",
     "cdk": "cdk",
     "prepare": "husky install",
     "prettier": "prettier --write ."

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   },
   "lint-staged": {
-    "*": [
+    "*.ts": [
       "prettier --write ."
     ]
   }


### PR DESCRIPTION
Adds a `npm run test-coverage` command for easy code coverage testing.

Fixes an issue with lint-staged sending non-typescript files to prettier